### PR TITLE
Fix three bugs(shaders/stroke/size) of Text Class (text_mobject.py)  …

### DIFF
--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -9,6 +9,9 @@ from manimlib.mobject.svg.svg_mobject import SVGMobject
 from manimlib.utils.config_ops import digest_config
 
 
+TEXT_MOB_SCALE_FACTOR = 0.05
+
+
 class TextSetting(object):
     def __init__(self, start, end, font, slant, weight, line_num=-1):
         self.start = start
@@ -50,7 +53,22 @@ class Text(SVGMobject):
         self.lsh = self.size if self.lsh == -1 else self.lsh
 
         file_name = self.text2svg()
+        self.remove_last_M(file_name)
         SVGMobject.__init__(self, file_name, **config)
+
+        nppc = self.n_points_per_cubic_curve
+        for each in self:
+            if len(each.points) == 0:
+                continue
+            points = each.points
+            last = points[0]
+            each.clear_points()
+            for index, point in enumerate(points):
+                each.append_points([point])
+                if index != len(points) - 1 and (index + 1) % nppc == 0 and any(point != points[index+1]):
+                    each.add_line_to(last)
+                    last = points[index + 1]
+            each.add_line_to(last)
 
         if self.t2c:
             self.set_color_by_t2c()
@@ -60,7 +78,14 @@ class Text(SVGMobject):
             self.set_color_by_t2g()
 
         # anti-aliasing
-        self.scale(0.1)
+        self.scale(TEXT_MOB_SCALE_FACTOR)
+
+    def remove_last_M(self, file_name):
+        with open(file_name, 'r') as fpr:
+            content = fpr.read()
+        content = re.sub(r'Z M [^[A-Za-z]*? "\/>', 'Z "/>', content)
+        with open(file_name, 'w') as fpw:
+            fpw.write(content)
 
     def find_indexes(self, word):
         m = re.match(r'\[([0-9\-]{0,}):([0-9\-]{0,})\]', word)


### PR DESCRIPTION
…(#1030)

* fix: remove the last M tag in svg files to make Text run in shaders branch

* fix: close the svg path manually to fix the bug of wrong stroke

* fix: remove Space mobjects in Text to fix the bug of TransformText

* feat: make Text and TextMobject equal in size

* this will lead to more bugs of setting color, so I delete it

Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)
2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
